### PR TITLE
new helmet adds security, need to use unsafe-inline due to swagger

### DIFF
--- a/server/common/server.ts
+++ b/server/common/server.ts
@@ -28,6 +28,15 @@ export class ExpressServer {
     this.app.set('appPath', `${root}client`);
     this.app.use(cors()); // allow cross-origin requests
     this.app.use(helmet()); // helmet helps secure Express apps with appropriate HTTP headers
+    //TODO remove again once swagger does no longer use inline scripts, https://github.com/swagger-api/swagger-ui/issues/3370
+    this.app.use(
+      helmet.contentSecurityPolicy({
+        directives: {
+          ...helmet.contentSecurityPolicy.getDefaultDirectives(),
+          'script-src': ["'unsafe-inline'"],
+        },
+      })
+    );
     this.app.use(bodyParser.json());
     this.app.use(bodyParser.urlencoded({ extended: true }));
     this.app.use(cookieParser(process.env.SESSION_SECRET)); // sign cookies. not sure what benefit is. See https://github.com/expressjs/cookie-parser


### PR DESCRIPTION
With the update of helmet to its latest version, it added more
content security policy rules. Unfortunately, swagger is still using
unsafe inline scripts and thus the api explorer does no longer work.
We need to wait for a fix, until then, we use src-script 'unsafe-inline'