### PR TITLE
remove TODO about GalleryValue optional category

### DIFF
--- a/server/common/typealias.ts
+++ b/server/common/typealias.ts
@@ -69,7 +69,6 @@ export interface GalleryValue {
   s: string;
   t: string;
   pgTit?: string;
-  //TODO @ralfhauser, should not every SCPT have a category?
   c?: Category;
   metadata?: ImageInfoMetadataCollection;
   description?: string;


### PR DESCRIPTION
according to Ralf Hauser the category is optional, wikidata only
encourages to set a category